### PR TITLE
Fix integer-truncation of spin±2 gradient filter in gradient_spin

### DIFF
--- a/falafel/qe.py
+++ b/falafel/qe.py
@@ -3,7 +3,6 @@ import numpy as np
 import healpy as hp
 import sys
 
-
 class pixelization(object):
     def __init__(self,shape=None,wcs=None,nside=None,dtype=np.float32,iter=0):
         self.dtype = dtype
@@ -87,12 +86,13 @@ def get_mlmax(alms):
         raise ValueError
     return hp.Alm.getlmax(asize)
 
-def filter_alms(alms,filt,lmin=None,lmax=None):
+def filter_alms(alms,pfilt,lmin=None,lmax=None):
     """
     Filter the alms with transfer function specified
     by filt (indexed starting at ell=0).
     """
     mlmax = get_mlmax(alms)
+    filt = pfilt.copy()
     ls = np.arange(filt.size)
     if lmax is not None:
         assert lmax<=ls.max()
@@ -146,7 +146,7 @@ def gradient_spin(px,alm,mlmax,spin):
     px = pixelization(nside=nside) # for healpix
     """
 
-    ells = np.arange(0,mlmax)
+    ells = np.arange(0,mlmax+1,dtype=float)
     if spin==0:
         fl = np.sqrt(ells*(ells+1.))
         spin_out = 1 ; comp = 0
@@ -173,7 +173,7 @@ def deflection_map_to_phi_curl_alms(px,dmap,mlmax):
     """
 
     res = px.map2alm_spin(dmap,lmax=mlmax,spin_alm=0,spin_transform=1)
-    ells = np.arange(0,mlmax)
+    ells = np.arange(0,mlmax+1,dtype=float)
     fl = np.sqrt(ells*(ells+1.))
     res = almxfl(res,fl)
     return res
@@ -208,35 +208,6 @@ def qe_spin_pol_deflection(px,X_Ealm,X_Balm,Y_Ealm,Y_Balm,mlmax):
         prod = enmap.enmap(prod,px.wcs)
     return prod/2
     
-def qe_temperature_only(px,Xalm,Yalm,mlmax):
-    """
-    px is a pixelization object, initialized like this:
-    px = pixelization(shape=shape,wcs=wcs) # for CAR
-    px = pixelization(nside=nside) # for healpix
-    """
-
-    dmap = qe_spin_temperature_deflection(px,Xalm,Yalm,mlmax)
-    return deflection_map_to_phi_curl_alms(px,dmap,mlmax)
-
-def qe_pol_only(px,X_Ealm,X_Balm,Y_Ealm,Y_Balm,mlmax):
-    """
-    px is a pixelization object, initialized like this:
-    px = pixelization(shape=shape,wcs=wcs) # for CAR
-    px = pixelization(nside=nside) # for healpix
-    """
-    dmap = qe_spin_pol_deflection(px,X_Ealm,X_Balm,Y_Ealm,Y_Balm,mlmax)
-    return deflection_map_to_phi_curl_alms(px,dmap,mlmax)
-
-def qe_mv(px,X_Talm,X_Ealm,X_Balm,Y_Talm,Y_Ealm,Y_Balm,mlmax):
-    """
-    px is a pixelization object, initialized like this:
-    px = pixelization(shape=shape,wcs=wcs) # for CAR
-    px = pixelization(nside=nside) # for healpix
-    """
-    dmap_t = qe_spin_temperature_deflection(px,X_Talm,Y_Talm,mlmax)
-    dmap_p = qe_spin_pol_deflection(px,X_Ealm,X_Balm,Y_Ealm,Y_Balm,mlmax)
-    return deflection_map_to_phi_curl_alms(px,dmap_t+dmap_p,mlmax),dmap_t,dmap_p
-
 
 def qe_all(px,response_cls_dict,mlmax,
            fTalm=None,fEalm=None,fBalm=None,
@@ -369,7 +340,7 @@ def qe_shear(px,mlmax,Talm=None,fTalm=None):
     px = pixelization(nside=nside) # for healpix
     output: curved sky shear estimator
     """
-    ells = np.arange(mlmax)
+    ells = np.arange(0,mlmax+1,dtype=float)
     #prepare temperature map
     rmapT=px.alm2map(np.stack((Talm,Talm)),spin=0,ncomp=1,mlmax=mlmax)[0]
     #find tbarf
@@ -400,7 +371,7 @@ def qe_m4(px,mlmax,Talm=None,fTalm=None):
     px = pixelization(nside=nside) # for healpix
     output: curved sky multipole=4 estimator
     """
-    ells = np.arange(mlmax)
+    ells = np.arange(0,mlmax+1,dtype=float)
     #prepare temperature map
     rmapT=px.alm2map(np.stack((Talm,Talm)),spin=0,ncomp=1,mlmax=mlmax)[0]
     #find tbarf

--- a/falafel/qe.py
+++ b/falafel/qe.py
@@ -152,12 +152,12 @@ def gradient_spin(px,alm,mlmax,spin):
         spin_out = 1 ; comp = 0
         sign = 1
     elif spin==(-2):
-        fl = ells * 0
+        fl = np.zeros_like(ells, dtype=float)
         fl[ells>=1] = np.sqrt((ells[ells>=1]-1)*(ells[ells>=1]+2.))
         spin_out = -1 ; comp = 1
         sign = 1
     elif spin==2:
-        fl = ells * 0
+        fl = np.zeros_like(ells, dtype=float)
         fl[ells>=2] = np.sqrt((ells[ells>=2]-2)*(ells[ells>=2]+3.))
         spin_out = 3 ; comp = 0
         sign = -1

--- a/tests/simple.py
+++ b/tests/simple.py
@@ -10,7 +10,7 @@ import pytempura
 import pickle
 
 # The estimators to test lensing for
-# ests = ['TT','mv','mvpol','EE','TE','EB','TB']
+#ests = ['TT','mv','mvpol','EE','TE','EB','TB']
 ests = ['mv']
 # ests = ['TT']
 
@@ -40,8 +40,6 @@ ucls,tcls = utils.get_theory_dicts_white_noise(beam_fwhm,noise_t)
 
 # Get normalizations
 Als = pytempura.get_norms(ests,ucls,ucls,tcls,lmin,lmax,k_ellmax=mlmax)
-
-res = {}
 
 # Filter
 Xdat = utils.isotropic_filter(alm,tcls,lmin,lmax)

--- a/tests/simple.py
+++ b/tests/simple.py
@@ -7,7 +7,6 @@ import os,sys
 import healpy as hp
 from falafel import qe,utils
 import pytempura
-import pickle
 
 # The estimators to test lensing for
 #ests = ['TT','mv','mvpol','EE','TE','EB','TB']
@@ -49,7 +48,6 @@ recon = qe.qe_all(px,ucls,mlmax,
                   fTalm=Xdat[0],fEalm=Xdat[1],fBalm=Xdat[2],
                   estimators=ests,
                   xfTalm=Xdat[0],xfEalm=Xdat[1],xfBalm=Xdat[2])
-
 # Get input kappa alms
 ikalm = utils.change_alm_lmax(utils.get_kappa_alm(sindex).astype(np.complex128),mlmax)
 
@@ -77,4 +75,3 @@ for est in ests:
     pl2.done(f'simple_recon_diff_{est}.png')
     pl._ax.set_ylim(1e-9,1e-5)
     pl.done(f'simple_recon_{est}.png')
-

--- a/tests/simple.py
+++ b/tests/simple.py
@@ -7,9 +7,10 @@ import os,sys
 import healpy as hp
 from falafel import qe,utils
 import pytempura
+import pickle
 
 # The estimators to test lensing for
-#ests = ['TT','mv','mvpol','EE','TE','EB','TB']
+# ests = ['TT','mv','mvpol','EE','TE','EB','TB']
 ests = ['mv']
 # ests = ['TT']
 
@@ -40,6 +41,8 @@ ucls,tcls = utils.get_theory_dicts_white_noise(beam_fwhm,noise_t)
 # Get normalizations
 Als = pytempura.get_norms(ests,ucls,ucls,tcls,lmin,lmax,k_ellmax=mlmax)
 
+res = {}
+
 # Filter
 Xdat = utils.isotropic_filter(alm,tcls,lmin,lmax)
 
@@ -48,7 +51,7 @@ recon = qe.qe_all(px,ucls,mlmax,
                   fTalm=Xdat[0],fEalm=Xdat[1],fBalm=Xdat[2],
                   estimators=ests,
                   xfTalm=Xdat[0],xfEalm=Xdat[1],xfBalm=Xdat[2])
-    
+
 # Get input kappa alms
 ikalm = utils.change_alm_lmax(utils.get_kappa_alm(sindex).astype(np.complex128),mlmax)
 
@@ -76,3 +79,4 @@ for est in ests:
     pl2.done(f'simple_recon_diff_{est}.png')
     pl._ax.set_ylim(1e-9,1e-5)
     pl.done(f'simple_recon_{est}.png')
+


### PR DESCRIPTION
Noticed a silent truncation bug: in these spin=2/-2 branch, `ells` are initiated to be int array. `fl = ells * 0` causes fl to be int array too, and then `fl[ells>=1] = np.sqrt(...)` silently truncates float to integer without warning. For `l<=30`, this is > 1%, for `l>=100`, the error should be < 0.5%, so maybe it's not too serious, but good to quantify the impact. 